### PR TITLE
在启动命令行中增加命令参数 MaxConcurrent

### DIFF
--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -66,7 +66,7 @@ func (s *Options) Flags() cliflag.NamedFlagSets {
 
 	// add MaxConcurrent args
 	// MaxConcurrent this is the maximum number of concurrent Reconciles which can be run. Defaults to 1.
-	mc := fss.FlagSet("Worker")
+	mc := fss.FlagSet("worker")
 
 	mc.IntVar(&s.MaxConcurrent, "maxconcurrent", 1, "MaxConcurrent this is the maximum number of concurrent Reconciles "+
 		"which can be run. Defaults to 1.")

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -29,6 +29,7 @@ type Options struct {
 	LeaderElect    bool
 	LeaderElection *leaderelection.LeaderElectionConfig
 	SyncPeriod     time.Duration
+	MaxConcurrent  int
 }
 
 //	fs.DurationVar(&o.config.IPVS.SyncPeriod.Duration, "ipvs-sync-period", o.config.IPVS.SyncPeriod.Duration, "The maximum interval of how often ipvs rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0.")
@@ -62,6 +63,13 @@ func (s *Options) Flags() cliflag.NamedFlagSets {
 		fl.Name = strings.Replace(fl.Name, "_", "-", -1)
 		kfs.AddGoFlag(fl)
 	})
+
+	// add MaxConcurrent args
+	// MaxConcurrent this is the maximum number of concurrent Reconciles which can be run. Defaults to 1.
+	mc := fss.FlagSet("Worker")
+
+	mc.IntVar(&s.MaxConcurrent, "maxconcurrent", 1, "MaxConcurrent this is the maximum number of concurrent Reconciles "+
+		"which can be run. Defaults to 1.")
 
 	return fss
 }

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -28,7 +28,6 @@ import (
 type Options struct {
 	LeaderElect    bool
 	LeaderElection *leaderelection.LeaderElectionConfig
-	SyncPeriod     time.Duration
 	MaxConcurrent  int
 }
 

--- a/cmd/app/server.go
+++ b/cmd/app/server.go
@@ -99,9 +99,11 @@ func run(s *options.Options, stopCh <-chan struct{}) error {
 	if err != nil {
 		klog.Fatalf("unable to set up overall controller manager: %v", err)
 	}
+	klog.V(0).Info("[****] MaxConcurrent value is ", s.MaxConcurrent)
 
 	controllers.Install(scheme)
 	clusterReconciler := &controllers.Reconciler{}
+	clusterReconciler.WorkNum = s.MaxConcurrent
 
 	if err = clusterReconciler.SetupWithManager(mgr); err != nil {
 		klog.Fatal("Unable to create cluster controller ", err)

--- a/config/charts/endpoints-operator/templates/deployment.yaml
+++ b/config/charts/endpoints-operator/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
             - --v
             - "{{ .Values.loglevel }}"
             - --leader-elect
+            - --maxconcurrent {{ .Values.maxconcurrent }}
           ports:
             - name: health
               containerPort: 8080

--- a/config/charts/endpoints-operator/values.yaml
+++ b/config/charts/endpoints-operator/values.yaml
@@ -47,3 +47,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+maxconcurrent: 1

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -49,6 +49,7 @@ type Reconciler struct {
 	cache     cache.Cache
 	scheme    *runtime.Scheme
 	LoopCount int
+	WorkNum   int
 }
 
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
@@ -86,7 +87,7 @@ func (c *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	c.Logger.V(4).Info("init reconcile controller service")
 	owner := &handler.EnqueueRequestForOwner{OwnerType: &v1beta1.ClusterEndpoint{}, IsController: false}
 	return ctrl.NewControllerManagedBy(mgr).WithEventFilter(&ResourceChangedPredicate{}).
-		Watches(&source.Kind{Type: &corev1.Service{}}, owner).WithOptions(runtimecontroller.Options{MaxConcurrentReconciles: 1}).
+		Watches(&source.Kind{Type: &corev1.Service{}}, owner).WithOptions(runtimecontroller.Options{MaxConcurrentReconciles: c.WorkNum}).
 		For(&v1beta1.ClusterEndpoint{}).Complete(c)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/sealyun/endpoints-operator/library v0.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
-	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
 	k8s.io/apiserver v0.17.2

--- a/go.sum
+++ b/go.sum
@@ -337,7 +337,6 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
在启动命令行中增加命令参数 MaxConcurrent, 启动controller时，加上`--maxconcurrent`参数，即可配置工作的进程数量